### PR TITLE
Add dependency to gdbm package on mingw

### DIFF
--- a/gdbm.gemspec
+++ b/gdbm.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/gdbm/extconf.rb"]
   spec.required_ruby_version = ">= 2.3.0"
+  spec.metadata["msys2_mingw_dependencies"] = "gdbm"
 end


### PR DESCRIPTION
RubyInstaller2 supports metadata tags for installation of dependent MSYS2/MINGW libraries. The openssl gem requires the mingw-openssl package to be installed on the system, which the gem installer takes care about, when this tag is set.

The feature is documented here: https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#msys2-library-dependency

Fixes https://github.com/oneclick/rubyinstaller2/issues/163

This tag was added to ruby-openssl as well: https://github.com/ruby/openssl/pull/134