### PR TITLE
Misc CI changes, add Windows Actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ '2.6.x', '2.5.x', '2.4.x' ]
     steps:
@@ -18,5 +19,7 @@ jobs:
       run: gem install bundler --no-document
     - name: Install dependencies
       run: bundle install
-    - name: Run test
-      run: rake
+    - name: Compile
+      run: rake compile
+    - name: Test
+      run: rake test

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -13,8 +13,8 @@ jobs:
     - uses: actions/checkout@master
     - name: Install packages
       run: |
-        sudo apt update -qy
-        sudo apt install libgdbm5 libgdbm-dev
+        sudo apt-get -qy update
+        sudo apt-get -qy install libgdbm5 libgdbm-dev
     - name: Set up RVM
       run: |
         curl -sSL https://get.rvm.io | bash
@@ -31,7 +31,11 @@ jobs:
       run: |
         source $HOME/.rvm/scripts/rvm
         bundle install
-    - name: Run test
+    - name: Compile
       run: |
         source $HOME/.rvm/scripts/rvm
-        rake
+        rake compile
+    - name: Test
+      run: |
+        source $HOME/.rvm/scripts/rvm
+        rake test

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,14 +6,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ '2.6.x', '2.5.x', '2.4.x' ]
     steps:
     - uses: actions/checkout@master
     - name: Install packages
       run: |
-        sudo apt update -qy
-        sudo apt install libgdbm5 libgdbm-dev
+        # 2019.12.13 below doesn't work
+        # sudo apt-get -qy update
+        sudo apt-get -qy install libgdbm5 libgdbm-dev
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
@@ -22,5 +24,9 @@ jobs:
       run: gem install bundler --no-document
     - name: Install dependencies
       run: bundle install
-    - name: Run test
-      run: rake
+    - name: Compile
+      run: |
+        rake compile
+    - name: Test
+      run: |
+        rake test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,27 @@
+name: windows
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '9.9.x', '2.6.x', '2.5.x', '2.4.x' ]
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Ruby
+        uses: MSP-Greg/actions-ruby@master
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          base:  update
+          mingw: gdbm
+      - name: Set up Bundler
+        run:  gem install bundler --no-document --conservative
+      - name: Install dependencies
+        run:  bundle install
+      - name: Compile
+        run:  rake compile
+      - name: Test
+        run:  rake test

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,9 @@ require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test/lib"
-  t.test_files = FileList['test/**/test_*.rb']
+  t.pattern = 'test/**/test_*.rb'
+  t.options = '--no-show-detail-immediately'
+  t.ruby_opts = %w[-v]
 end
 
 require 'rake/extensiontask'

--- a/test/gdbm/test_gdbm.rb
+++ b/test/gdbm/test_gdbm.rb
@@ -10,6 +10,13 @@ if defined? GDBM
   require 'tmpdir'
   require 'fileutils'
 
+  # not needed in ruby/ruby, needed in ruby/gdbm
+  # skips only run in Windows as of 2019.12.13
+  unless Test::Unit::TestCase.respond_to? :skip
+    Test::Unit::TestCase.send :alias_method, :skip, :omit
+    puts GDBM::VERSION
+  end
+
   class TestGDBM_RDONLY < Test::Unit::TestCase
     def TestGDBM_RDONLY.uname_s
       require 'rbconfig'

--- a/test/lib/envutil.rb
+++ b/test/lib/envutil.rb
@@ -150,6 +150,7 @@ module EnvUtil
         timeout_error = nil
       else
         status = terminate(pid, signal, opt[:pgroup], reprieve)
+        terminated = Time.now
       end
       stdout = th_stdout.value if capture_stdout
       stderr = th_stderr.value if capture_stderr && capture_stderr != :merge_to_stdout
@@ -161,7 +162,7 @@ module EnvUtil
       if timeout_error
         bt = caller_locations
         msg = "execution of #{bt.shift.label} expired timeout (#{timeout} sec)"
-        msg = Test::Unit::Assertions::FailDesc[status, msg, [stdout, stderr].join("\n")].()
+        msg = failure_description(status, terminated, msg, [stdout, stderr].join("\n"))
         raise timeout_error, msg, bt.map(&:to_s)
       end
       return stdout, stderr, status
@@ -286,6 +287,37 @@ module EnvUtil
     end
   end
 
+  def self.failure_description(status, now, message = "", out = "")
+    pid = status.pid
+    if signo = status.termsig
+      signame = Signal.signame(signo)
+      sigdesc = "signal #{signo}"
+    end
+    log = diagnostic_reports(signame, pid, now)
+    if signame
+      sigdesc = "SIG#{signame} (#{sigdesc})"
+    end
+    if status.coredump?
+      sigdesc = "#{sigdesc} (core dumped)"
+    end
+    full_message = ''.dup
+    message = message.call if Proc === message
+    if message and !message.empty?
+      full_message << message << "\n"
+    end
+    full_message << "pid #{pid}"
+    full_message << " exit #{status.exitstatus}" if status.exited?
+    full_message << " killed by #{sigdesc}" if sigdesc
+    if out and !out.empty?
+      full_message << "\n" << out.b.gsub(/^/, '| ')
+      full_message.sub!(/(?<!\n)\z/, "\n")
+    end
+    if log
+      full_message << "Diagnostic reports:\n" << log.b.gsub(/^/, '| ')
+    end
+    full_message
+  end
+
   def self.gc_stress_to_class?
     unless defined?(@gc_stress_to_class)
       _, _, status = invoke_ruby(["-e""exit GC.respond_to?(:add_stress_to_class)"])
@@ -304,7 +336,6 @@ if defined?(RbConfig)
     end
     dir = File.dirname(ruby)
     CONFIG['bindir'] = dir
-    Gem::ConfigMap[:bindir] = dir if defined?(Gem::ConfigMap)
   end
 end
 


### PR DESCRIPTION
1. Rakefile - added '-v' for ruby, '--no-show-detail-immediately' for tests

2. test/gdbm/test_gdbm.rb - added alias for skip, output GDBM version
3. test/lib/envutil.rb - updated from ruby/ruby

4. Workflows - added 'fail-fast: false' so all Ruby versions run, split compile and test

5. Windows - added workflow, runs Ruby 2.4 thru master
  5.1 install current Rubies
  5.2 update MSYS2 gcc tools

Current GDBM versions used are:

Ubuntu  1.14.1. 03/01/2018
MacOS   1.18.1. 27/10/2018
Windows 1.18.1. 27/10/2018